### PR TITLE
Fix: Huey altimeter rounding error

### DIFF
--- a/wwt/ufcPatch/aircraft/ufcPatchHuey.lua
+++ b/wwt/ufcPatch/aircraft/ufcPatchHuey.lua
@@ -8,11 +8,13 @@ function ufcPatchHuey.generateUFCData()
     local MainPanel = GetDevice(0)
 
     -- Got these argument values from: <DCS_INSTALL>\Mods\aircraft\Uh-1H\Cockpit\Scripts\mainpanel_init.lua
+    -- DCS get_argument_value returns floats for these values. Example: 7 = .069999999999901. We need to round to get the proper digit
+    -- By adding .05 and flooring we get the proper digit shown on the altimeter.
     local digits = {
-        math.floor(MainPanel:get_argument_value(468) * 10),
-        math.floor(MainPanel:get_argument_value(469) * 10),
-        math.floor(MainPanel:get_argument_value(470) * 10),
-        math.floor(MainPanel:get_argument_value(471) * 10)
+        math.floor((MainPanel:get_argument_value(468) + 0.05) * 10),
+        math.floor((MainPanel:get_argument_value(469)+ 0.05) * 10),
+        math.floor((MainPanel:get_argument_value(470)+ 0.05) * 10),
+        math.floor((MainPanel:get_argument_value(471)+ 0.05) * 10)
     }
 
     -- Parse digits and build the radar alt string


### PR DESCRIPTION
DCS get_argument_value was returning floats for the digits and there was a rounding error for any altitude with a 6 in it. This fix adds a proper rounding function to avoid this for all digits on the huey.