### PR TITLE
Update ufcPatch.lua

### DIFF
--- a/wwt/ufcPatch/ufcPatch.lua
+++ b/wwt/ufcPatch/ufcPatch.lua
@@ -32,9 +32,15 @@ function ufcPatch.generateUFCExport(deltaTime, moduleName)
             return ufcPatchHuey.generateUFCData()
         end
 
-    -- A-10C_2 sends static data once
+    -- A-10C_2 sends throttled data every 0.2 seconds
     elseif moduleName == "A-10C_2" then
-        if ufcExportClock.canExportStaticData then
+        if ufcExportClock.canTransmitLatestPayload then
+            return ufcPatchA10C2.generateUFCData()
+        end
+		
+    -- A-10C sends throttled data every 0.2 seconds
+    elseif moduleName == "A-10C" then
+        if ufcExportClock.canTransmitLatestPayload then
             return ufcPatchA10C2.generateUFCData()
         end
 


### PR DESCRIPTION
Updates the A-10C_2 from static to constant to fix a bug where the data would not display on the UFC if the A-10C_2 was not the first aircraft flown during the mission. Also added support for the (original) A-10C.